### PR TITLE
Ignore SSL option

### DIFF
--- a/api/contract.go
+++ b/api/contract.go
@@ -1,8 +1,8 @@
 package api
 
 import (
-	"github.com/netsage-project/grafana-dashboard-manager/config"
 	"github.com/grafana-tools/sdk"
+	"github.com/netsage-project/grafana-dashboard-manager/config"
 	"github.com/spf13/viper"
 )
 
@@ -37,10 +37,10 @@ type DashNGoImpl struct {
 
 func (s *DashNGoImpl) init() {
 	s.grafanaConf = config.GetDefaultGrafanaConfig()
-	s.configRef = config.Config()
+	s.configRef = config.Config().ViperConfig()
 	s.client = s.Login()
 	s.adminClient = s.AdminLogin()
-	s.debug = s.configRef.GetBool("global.debug")
+	s.debug = config.Config().IsDebug()
 
 }
 

--- a/api/dashboards.go
+++ b/api/dashboards.go
@@ -23,7 +23,8 @@ func (s *DashNGoImpl) ListDashboards(filters Filter) []sdk.FoundBoard {
 	ctx := context.Background()
 	orgs, err := s.client.GetAllOrgs(ctx)
 	if err != nil {
-		log.Fatalf("Error getting organizations: %s", err.Error())
+		log.Warnf("Error getting organizations: %s", err.Error())
+		orgs = make([]sdk.Org, 0)
 	}
 	if s.grafanaConf.Organization != "" {
 		var ID uint

--- a/api/login.go
+++ b/api/login.go
@@ -1,14 +1,23 @@
 package api
 
 import (
+	"crypto/tls"
 	"fmt"
-	"log"
+
+	"net/http"
 
 	"github.com/grafana-tools/sdk"
+	"github.com/netsage-project/grafana-dashboard-manager/config"
+	log "github.com/sirupsen/logrus"
 )
 
 //Login: Logs into grafana returning a client instance using Token or Basic Auth
 func (s *DashNGoImpl) Login() *sdk.Client {
+
+	//If ignoreSSL create custom http client
+	if config.Config().IgnoreSSL() {
+		ignoreSSLErrors()
+	}
 	if s.grafanaConf.APIToken != "" {
 		return s.tokenLogin()
 	} else if s.grafanaConf.UserName != "" && s.grafanaConf.Password != "" {
@@ -30,10 +39,19 @@ func (s *DashNGoImpl) AdminLogin() *sdk.Client {
 
 }
 
+//ignoreSSLErrors when called replaces the default http client to ignore invalid SSL issues.
+//only to be used for testing, highly discouraged in production.
+func ignoreSSLErrors() {
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	httpclient := &http.Client{Transport: customTransport}
+	sdk.DefaultHTTPClient = httpclient
+
+}
+
 //tokenLogin: given a URL and token return the client
 func (s *DashNGoImpl) tokenLogin() *sdk.Client {
 	client, err := sdk.NewClient(s.grafanaConf.URL, s.grafanaConf.APIToken, sdk.DefaultHTTPClient)
-
 	if err != nil {
 		log.Fatal("failed to get a valid client using token auth")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func initConfig() {
-	configProvider := config.Config()
+	configProvider := config.Config().ViperConfig()
 	setupGrafanaClient()
 	log.Debug("Creating output locations")
 	dir := configProvider.GetString("env.output.datasources")

--- a/conf/importer-example.yml
+++ b/conf/importer-example.yml
@@ -56,3 +56,4 @@ contexts:
 
 global:
   debug: true
+  ignore_ssl_errors: false ##when set to true will ignore invalid SSL errors

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSetup(t *testing.T) {
-	conf := config.Config()
+	conf := config.Config().ViperConfig()
 	assert.NotNil(t, conf)
 	context := conf.GetString("context_name")
 	assert.Equal(t, context, "qa")

--- a/documentation/content/docs/_index.md
+++ b/documentation/content/docs/_index.md
@@ -4,5 +4,5 @@ weight: 1
 ---
 
 
-{{< button "./usage_guide" "Usage Guide" "mb-1" >}}
+{{< button "./configuration" "Configuration" "mb-1" >}}
 

--- a/documentation/content/docs/configuration.md
+++ b/documentation/content/docs/configuration.md
@@ -1,0 +1,38 @@
+---
+title: "Configuration"
+weight: 14
+---
+## Getting started
+
+This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
+
+
+
+
+
+make a copy of [conf/importer-example.yml](https://github.com/netsage-project/grafana-dashboard-manager/blob/master/conf/importer-example.yml) and name it `conf/importer.yml` You'll need GRAFANA ADMINISTRATIVE privileges to proceed.
+
+
+### Authentication
+
+
+You can use either an Auth Token or username/password credentials.  If you configure both then the Token is given priority.
+
+Watched folders under grafana is a white list of folders that are being managed by the tool.  By default only "General" is managed.  
+
+env.output defines where the files will be saved and imported from.
+
+### Global Flags
+
+`globals.debug` when set will print a more verbose output (Development In Progress)
+`globals.ignore_ssl_errors` when set will disregard any SSL errors and proceed as expected
+
+
+### Building/Running the app
+
+Running it then should be as simple as:
+
+```bash
+$ make build
+$ ./bin/grafana-dashboard-manager
+```

--- a/documentation/content/docs/developer.md
+++ b/documentation/content/docs/developer.md
@@ -1,0 +1,30 @@
+---
+title: "Developer Guide"
+weight: 14
+---
+## Making a release
+
+Install goreleaser.
+
+```sh
+brew install goreleaser/tap/goreleaser
+brew reinstall goreleaser`
+```
+
+export your GITHUB_TOKEN.
+
+```sh
+export GITHUB_TOKEN="secret"
+```
+
+git tag v0.1.0
+goreleaser release
+
+
+NOTE: CI/CD pipeline should do all this automatically.  `make release-snapshot` is used to test the release build process.  Once a build is tagged all artifacts should be built automatically and attached to the github release page.
+
+NOTE: mac binary are not signed so will likely complain.
+
+
+
+

--- a/documentation/content/docs/usage_guide.md
+++ b/documentation/content/docs/usage_guide.md
@@ -2,19 +2,8 @@
 title: "Usage Guide"
 weight: 14
 ---
-## Getting started
 
-This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
-
-### Configuring Auth
-
-make a copy of `conf/importer-example.yml` and name it `conf/importer.yml` You'll need administrative privileges to proceed.
-
-You can use either an Auth Token or username/password credentials.  If you configure both then the Token is given priority.
-
-Watched folders under grafana is a white list of folders that are being managed by the tool.  By default only "General" is managed.  
-
-env.output defines where the files will be saved and imported from.
+Every namespace supporting CRUD operations has the functions: list, import, export, clear operating on only the monitored folders.
 
 ### Contexts
 
@@ -28,30 +17,9 @@ ctx is shorthand for context
 ./bin/grafana-dashboard-manager ctx set -c production -- updates the active config and sets it to the request value.
 ```
 
-### Users
-
-Only supported with basic auth.  Users is the only one where basic auth is given priority.  API Auth is not supported, so will try to use basic auth if configured otherwise will warn the user and exit.
-
-```sh
-./bin/grafana-dashboard-manager users list -- Lists all known users
-./bin/grafana-dashboard-manager users promote -u user@foobar.com -- promotes the user to a grafana admin
-```
-
-
-### Running the app
-
-Running it then should be as simple as:
-
-```bash
-$ make build
-$ ./bin/grafana-dashboard-manager
-```
-
-Every namespace has three functions: list, import, export, clear operating on only the monitored folders.
-
 #### Dashboards
 
-Dashboards are imported or exported from _organization_ specified in configuration file otherwise current organitazione user is used.
+Dashboards are imported or exported from _organization_ specified in configuration file otherwise current organization user is used.
 
 All commands can use `dashboards` or `dash` to manage dashboards
 
@@ -64,8 +32,8 @@ All commands can use `dashboards` or `dash` to manage dashboards
 
 #### DataSources
 
-DataSources credentials are keyed by the name of the DataSource.  See see [config example](https://github.com/netsage-project/grafana-dashboard-manager/blob/master/conf/importer-example.yml).  If the datasource JSON doesn't have auth enabled, the credentials are igored.  If Credentials are missing, we'll fall back on default credentials if any exist.  The password is set as a value for basicAuthPassword in the API payload.
-Datasources are imported or exported from _organization_ specified in configuration file otherwise current organitazione user is used.
+DataSources credentials are keyed by the name of the DataSource.  See see [config example](https://github.com/netsage-project/grafana-dashboard-manager/blob/master/conf/importer-example.yml).  If the datasource JSON doesn't have auth enabled, the credentials are ignored.  If Credentials are missing, we'll fall back on default credentials if any exist.  The password is set as a value for basicAuthPassword in the API payload.
+Datasources are imported or exported from _organization_ specified in configuration file otherwise current organization user is used.
 
 
 All commands can use `datasources` or `ds` to manage datasources
@@ -84,24 +52,12 @@ Command can use `organizations` or `org` to manage organizations.
 ./bin/grafana-dashboard-manager org list -- Lists all organizations
 ```
 
-## Making a release
+### Users
 
-Install goreleaser.
-
-```sh
-brew install goreleaser/tap/goreleaser
-brew reinstall goreleaser`
-```
-
-export your GITHUB_TOKEN.
+Only supported with basic auth.  Users is the only one where basic auth is given priority.  API Auth is not supported, so will try to use basic auth if configured otherwise will warn the user and exit.
 
 ```sh
-export GITHUB_TOKEN="secret"
+./bin/grafana-dashboard-manager users list -- Lists all known users
+./bin/grafana-dashboard-manager users promote -u user@foobar.com -- promotes the user to a grafana admin
 ```
-
-git tag v0.1.0
-goreleaser release
-
-
-
 

--- a/integration_tests/integration_common.go
+++ b/integration_tests/integration_common.go
@@ -12,7 +12,7 @@ import (
 )
 
 func initTest(t *testing.T) (api.ApiService, *viper.Viper) {
-	conf := config.Config()
+	conf := config.Config().ViperConfig()
 	assert.NotNil(t, conf)
 	conf.Set("context_name", "testing")
 	//Hack for Local testing


### PR DESCRIPTION
ChangeLog:
  - Allows for a config option to ignore invalid SSL certificates.
  - Allows for graceful failover when Orgs cannot be obtained.

Fixes #37 and #35